### PR TITLE
fix(worker): unregister legacy Gatsby service worker

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,6 +7,10 @@
  *
  * - `POST /api/contact` or `/api/contact/` → delegated to `onRequest`.
  * - Exact-match legacy redirect source              → 301 redirect.
+ * - `/sw.js` or `/service-worker.js`                → SW unregistration JS
+ *                                                (temporary migration — drops
+ *                                                old Gatsby SW on legacy clients
+ *                                                during the Astro transition).
  * - Everything else                                  → `ASSETS` static binding.
  */
 
@@ -40,6 +44,57 @@ interface WorkerFunctionContext {
 }
 
 // ---------------------------------------------------------------------------
+// Service Worker unregistration script  (temporary migration code)
+//
+// During the Gatsby → Astro migration period, old clients may still have
+// the Gatsby service worker registered.  This script unregisters it so
+// that those clients fall back to plain HTTP loading.
+//
+// Once enough time has passed (i.e. most visitors have received this
+// script and had their SW unregistered), both the script and the routes
+// in wrangler.toml (`run_worker_first`) can be removed.
+// ---------------------------------------------------------------------------
+
+/**
+ * JavaScript served at `/sw.js` and `/service-worker.js` that unregisters any
+ * stale service worker (typically the Gatsby SW from the previous blog) and
+ * purges all caches.
+ *
+ * This is a temporary migration measure — for the duration of the Gatsby →
+ * Astro transition, the Worker serves this script so that legacy clients
+ * gracefully clean up their old SW registration without manual intervention.
+ */
+const SW_UNREGISTER_SCRIPT = `
+self.addEventListener("install", (event) => {
+  // Take over immediately without waiting for page refresh.
+  self.skipWaiting()
+})
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      // 1. Wipe every previously cached resource.
+      const cacheNames = await caches.keys()
+      await Promise.all(cacheNames.map((name) => caches.delete(name)))
+
+      // 2. Unregister this service worker entirely.
+      await self.registration.unregister()
+
+      // 3. Reload every open window/tab that is still controlled by this SW,
+      //    so they load fresh without any SW interference.
+      const windowClients = await self.clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      })
+      await Promise.all(
+        windowClients.map((client) => client.navigate(client.url)),
+      )
+    })(),
+  )
+})
+`
+
+// ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
 
@@ -70,7 +125,21 @@ export default {
       })
     }
 
-    // 3. Static assets fallback.
+    // 3. Service Worker unregistration — return JS that wipes the old SW.
+    if (pathname === "/sw.js" || pathname === "/service-worker.js") {
+      return new Response(SW_UNREGISTER_SCRIPT, {
+        headers: {
+          "Content-Type": "application/javascript; charset=utf-8",
+          "Cache-Control":
+            "no-store, no-cache, must-revalidate, proxy-revalidate",
+          "Pragma": "no-cache",
+          "Expires": "0",
+          "Service-Worker-Allowed": "/",
+        },
+      })
+    }
+
+    // 4. Static assets fallback.
     return env.ASSETS.fetch(request)
   },
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,10 +27,16 @@ binding = "ASSETS"
 # unmatched routes (Astro generates dist/404.html from src/pages/404.astro).
 html_handling = "force-trailing-slash"
 not_found_handling = "404-page"
-# Browser form submissions send `Sec-Fetch-Mode: navigate`, which makes the
-# asset router treat the request as a page navigation and answer 405 before
-# the Worker runs. Route /api/* to the Worker unconditionally.
-run_worker_first = ["/api/*"]
+# Route these paths to the Worker unconditionally (the asset router would
+# otherwise intercept them):
+#   /api/*           — Contact form submission endpoint (POST handler).
+#   /sw.js, /service-worker.js — Temporary migration routes: serve the old
+#                                 Gatsby Service Worker unregistration
+#                                 script from the Worker.  These can be
+#                                 removed once a sufficient migration window
+#                                 has passed (most clients will have received
+#                                 the unregistration script by then).
+run_worker_first = ["/api/*", "/sw.js", "/service-worker.js"]
 
 # Cloudflare Email Service — Email Sending binding
 # Docs: https://developers.cloudflare.com/email-service/


### PR DESCRIPTION
Serve a self-unregistering service worker script at /sw.js and /service-worker.js during the Gatsby → Astro migration period. The script wipes all caches, unregisters itself, and reloads controlled clients so legacy visitors gracefully fall back to plain HTTP loading.

- Add SW_UNREGISTER_SCRIPT constant with install/activate handlers
- Route /sw.js and /service-worker.js to return the script with no-cache headers and Service-Worker-Allowed: /
- Register /sw.js and /service-worker.js in wrangler.toml's run_worker_first to bypass asset router interception

This is temporary; both the route and the script can be removed once the migration window has passed.