### PR TITLE
feat(contact): add Cloudflare Turnstile bot verification

### DIFF
--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -89,6 +89,7 @@ export interface ContactEnv {
   readonly CONTACT_DB?: D1Database
   readonly CONTACT_TO_EMAIL?: string
   readonly CONTACT_FROM_EMAIL?: string
+  readonly TURNSTILE_SECRET_KEY?: string
 }
 
 /** Minimal subset of the Cloudflare Pages Function context we actually use. */
@@ -103,6 +104,9 @@ interface PagesFunctionContext {
 
 const SUCCESS_REDIRECT_URL = "/contact/success/"
 const FORM_REDIRECT_URL = "/contact/"
+
+const TURNSTILE_SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 
 /** Maximum allowed length for each input field. */
 const LIMITS = {
@@ -168,6 +172,61 @@ function escapeHtml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;")
+}
+
+/**
+ * Verify a Turnstile token against Cloudflare's siteverify endpoint.
+ *
+ * Returns:
+ *   { ok: true }                      – token is valid
+ *   { ok: false; reason: "..." }      – token missing/invalid (treat as bot)
+ *   { ok: false; reason: "misconfig" }– secret not configured (fail closed)
+ *
+ * Never throws; network/parse errors resolve to ok:false. Errors are logged
+ * server-side via console.error and never exposed to the client.
+ */
+async function verifyTurnstile(
+  env: ContactEnv,
+  token: string | undefined,
+  remoteIp: string | undefined,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const secret = env.TURNSTILE_SECRET_KEY
+  if (!secret) {
+    console.error(
+      "Contact form: TURNSTILE_SECRET_KEY is not configured — cannot verify Turnstile.",
+    )
+    return { ok: false, reason: "misconfig" }
+  }
+  const trimmed = token?.trim() ?? ""
+  if (trimmed.length === 0) {
+    return { ok: false, reason: "missing_token" }
+  }
+  try {
+    const body = new FormData()
+    body.append("secret", secret)
+    body.append("response", trimmed)
+    if (remoteIp) body.append("remoteip", remoteIp)
+    const res = await fetch(TURNSTILE_SITEVERIFY_URL, {
+      method: "POST",
+      body,
+    })
+    const data = (await res.json()) as {
+      success?: boolean
+      "error-codes"?: string[]
+    }
+    if (data.success === true) {
+      return { ok: true }
+    }
+    console.error(
+      "Contact form: Turnstile verification failed —",
+      (data["error-codes"] ?? []).join(", ") || "unknown",
+    )
+    return { ok: false, reason: "verification_failed" }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    console.error("Contact form: Turnstile siteverify threw —", detail)
+    return { ok: false, reason: "verification_failed" }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -409,11 +468,13 @@ export const onRequest = async (
   let rawEmail: string | undefined
   let rawContext: string | undefined
   let rawBotField: string | undefined
+  let rawTurnstileToken: string | undefined
   try {
     rawName = textField(form, "name")
     rawEmail = textField(form, "email")
     rawContext = textField(form, "context")
     rawBotField = textField(form, "botField")
+    rawTurnstileToken = textField(form, "cf-turnstile-response")
   } catch {
     return formRedirect("invalid_request")
   }
@@ -422,6 +483,17 @@ export const onRequest = async (
   const botField = rawBotField?.trim() ?? ""
   if (botField.length > 0) {
     return redirect(SUCCESS_REDIRECT_URL, 303)
+  }
+
+  // 4.5 Turnstile bot check — verify the token via Cloudflare siteverify.
+  const remoteIp = request.headers.get("CF-Connecting-IP") ?? undefined
+  const turnstileResult = await verifyTurnstile(
+    env,
+    rawTurnstileToken,
+    remoteIp,
+  )
+  if (!turnstileResult.ok) {
+    return formRedirect("verification_failed")
   }
 
   // 5. Validate.

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -7,6 +7,8 @@ interface StatusMessage {
   readonly body: string
 }
 
+const TURNSTILE_SITEKEY = import.meta.env.PUBLIC_TURNSTILE_SITEKEY
+
 const STATUS_MESSAGES: Record<string, StatusMessage> = {
   invalid_request: {
     type: "error",
@@ -22,6 +24,11 @@ const STATUS_MESSAGES: Record<string, StatusMessage> = {
     type: "error",
     heading: "送信処理で問題が発生しました",
     body: "時間をおいて、もう一度送信してください。問題が続く場合は Twitter DM でお問い合わせください。",
+  },
+  verification_failed: {
+    type: "error",
+    heading: "送信前の確認に失敗しました",
+    body: "ボットでないことの確認に失敗しました。ページを再読み込みするか、確認にチェックを入れてから、もう一度送信してください。",
   },
 }
 ---
@@ -53,6 +60,12 @@ const STATUS_MESSAGES: Record<string, StatusMessage> = {
         </div>
       ))
     }
+
+    <script
+      is:inline
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer></script>
 
     <form method="POST" action="/api/contact" class="contact-form">
       <!-- Honeypot field: visually hidden, bots will fill it in -->
@@ -88,6 +101,13 @@ const STATUS_MESSAGES: Record<string, StatusMessage> = {
         </label>
         <textarea id="field-context" name="context" rows="6" required
         ></textarea>
+      </div>
+
+      <div
+        class="cf-turnstile"
+        data-sitekey={TURNSTILE_SITEKEY}
+        data-action="turnstile-spin-v1"
+      >
       </div>
 
       <button type="submit" class="submit-button">送信する</button>
@@ -139,6 +159,13 @@ const STATUS_MESSAGES: Record<string, StatusMessage> = {
         el.hidden = true
       }
     })
+
+    function resetTurnstile() {
+      const ts = (window as unknown as {
+        turnstile?: { reset: (widget?: string) => void }
+      }).turnstile
+      ts?.reset()
+    }
 
     function showStatus(key: string) {
       // Hide all first
@@ -200,8 +227,10 @@ const STATUS_MESSAGES: Record<string, StatusMessage> = {
         const errorStatus =
           finalUrl.searchParams.get("status") ?? "server_error"
         showStatus(errorStatus)
+        resetTurnstile()
       } catch {
         showStatus("server_error")
+        resetTurnstile()
       } finally {
         setSubmitting(false)
       }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,9 +1,10 @@
 # Cloudflare Workers configuration
 # Docs: https://developers.cloudflare.com/workers/
 #
-# CONTACT_TO_EMAIL / CONTACT_FROM_EMAIL are Worker secrets, set via:
+# CONTACT_TO_EMAIL / CONTACT_FROM_EMAIL / TURNSTILE_SECRET_KEY are Worker secrets, set via:
 #   wrangler secret put CONTACT_TO_EMAIL
 #   wrangler secret put CONTACT_FROM_EMAIL
+#   wrangler secret put TURNSTILE_SECRET_KEY
 # Secrets survive `wrangler deploy`. Do NOT set them as plain-text variables
 # in the dashboard — those are deleted on every `wrangler deploy` because
 # this file does not declare them (and `keep_vars` is not enabled).


### PR DESCRIPTION
- Verify Turnstile token via siteverify in the contact Worker handler
- Add widget to the form, gated with fail-closed verification
- Configure sitekey via PUBLIC_TURNSTILE_SITEKEY env var